### PR TITLE
Adapt build scripts to Heroku changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "lint": "vue-cli-service lint",
     "test:e2e": "vue-cli-service test:e2e",
     "test:unit": "vue-cli-service test:unit",
-    "postinstall": "vue-cli-service build",
     "start": "node server.js"
   },
   "dependencies": {
@@ -74,5 +73,6 @@
       "vue-cli-service lint",
       "git add"
     ]
-  }
+  },
+  "heroku-run-build-script": true
 }


### PR DESCRIPTION
It fixes the warning:

```
remote: -----> Change to Node.js build process 
remote: On March 11, 2019 Heroku will begin executing the "build" script defined in package.json
remote: by default. This application may be affected by this change.
```